### PR TITLE
Fix for upstream change

### DIFF
--- a/src/lib/Tisch/Internal/Kol.hs
+++ b/src/lib/Tisch/Internal/Kol.hs
@@ -56,6 +56,7 @@ import qualified Data.Time
 import Data.Typeable (Typeable)
 import qualified Data.UUID
 import Data.Word
+import qualified Database.PostgreSQL.Simple.FromField as Pg
 import qualified Database.PostgreSQL.Simple.Types as Pg
 import GHC.Exts (Constraint)
 import qualified GHC.TypeLits as GHC
@@ -83,7 +84,7 @@ instance forall a b.
           h :: O.Column (PGArrayn a) -> O.Column (O.Nullable a)
           h = O.unsafeCoerceColumn
       in OI.QueryRunnerColumn (P.lmap h c)
-           ((fmap . fmap . fmap) Pg.fromPGArray (OI.arrayFieldParser f))
+           ((fmap . fmap . fmap) Pg.fromPGArray (Pg.pgArrayFieldParser f))
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Opaleye's RunQuery.hs `arrayFieldParser` was temporary code waiting
for an upstream change in PostgreSQL-Simple. This was implemented,
but broke Tisch.

This commit specifically: https://github.com/tomjaguarpaw/haskell-opaleye/commit/c068ba9d5da49735ade354717aa12e4e6d32ef9c#diff-e8eff9c752a345c1a7f2e9c1c27a2311