### PR TITLE
Fix runInsert variants to not throw errors when results are correct

### DIFF
--- a/src/lib/Tisch/Run.hs
+++ b/src/lib/Tisch/Run.hs
@@ -327,7 +327,7 @@ runInsertRaw conn t = \case
   ws -> do
     nAffected <- runInsertRawNoCountCheck conn t ws
     let nExpected = fromIntegral (length ws) :: Int64
-    when (nExpected == nAffected) $ do
+    when (nExpected /= nAffected) $ do
        let sql = O.arrangeInsertManySql (unRawTable t) (NEL.fromList ws)
        Cx.throwM (ErrNumRows nExpected nAffected (Just sql))
 


### PR DESCRIPTION
Pretty simple mistake. Running runInsert1 was throwing when it shouldn't have been and I determined it to be this.