### PR TITLE
version bump for recent lts

### DIFF
--- a/tisch.cabal
+++ b/tisch.cabal
@@ -34,12 +34,12 @@ library
       Tisch.Internal.Table
       Tisch.Internal.Window
   build-depends:
-      aeson >=0.11 && <0.12
+      aeson >=0.11 && <1.1
     , base >=4.7 && <5.0
     , bytestring
     , case-insensitive
     , exceptions >=0.8 && <0.9
-    , lens >=4.14 && <4.15
+    , lens >=4.14 && <4.16
     , mtl >=2.2 && <2.3
     , opaleye >=0.5 && <0.6
     , postgresql-simple


### PR DESCRIPTION
I'm using `tisch` in a sort of large project and am having dependency problems because of the `aeson` and `lens` versions. `aeson` doesn't seem to be used that heavily, so seems ok. With `lens` it's not clear to me, but your tests compile and my application's test still pass. 