### PR TITLE
add database to connection type

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -81,7 +81,7 @@ query2 = proc () -> do
   (t,_,_,_) <- query1 -< ()
   returnA -< t
 
-outQuery2 :: Allow 'Fetch ps => Conn ps Db1 -> IO [HsR Table1]
+outQuery2 :: Allow 'Fetch ps => Conn Db1 ps -> IO [HsR Table1]
 outQuery2 conn = runQuery conn query2
 
 query3 :: Query Db1 () (PgRN Table1)
@@ -89,10 +89,10 @@ query3 = proc () -> do
   (_,_,_,t) <- query1 -< ()
   returnA -< t
 
-outQuery3 :: Allow 'Fetch ps => Conn ps Db1 -> IO [Maybe (HsR Table1)]
+outQuery3 :: Allow 'Fetch ps => Conn Db1 ps -> IO [Maybe (HsR Table1)]
 outQuery3 conn = runQuery conn query3
 
-update1 :: Allow 'Update ps => Conn ps Db1 -> IO Int64
+update1 :: Allow 'Update ps => Conn Db1 ps -> IO Int64
 update1 conn = runUpdate conn Table1 upd fil
   where
     fil :: PgR Table1 -> Kol PGBool
@@ -102,6 +102,6 @@ update1 conn = runUpdate conn Table1 upd fil
 
 outQuery1
   :: Allow 'Fetch ps
-  => Conn ps Db1
+  => Conn Db1 ps
   -> IO [(HsR Table1, HsR Table1, HsR Table1, Maybe (HsR Table1))]
 outQuery1 conn = runQuery conn query1

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -81,7 +81,7 @@ query2 = proc () -> do
   (t,_,_,_) <- query1 -< ()
   returnA -< t
 
-outQuery2 :: Allow 'Fetch ps => Conn ps -> IO [HsR Table1]
+outQuery2 :: Allow 'Fetch ps => Conn ps Db1 -> IO [HsR Table1]
 outQuery2 conn = runQuery conn query2
 
 query3 :: Query Db1 () (PgRN Table1)
@@ -89,10 +89,10 @@ query3 = proc () -> do
   (_,_,_,t) <- query1 -< ()
   returnA -< t
 
-outQuery3 :: Allow 'Fetch ps => Conn ps -> IO [Maybe (HsR Table1)]
+outQuery3 :: Allow 'Fetch ps => Conn ps Db1 -> IO [Maybe (HsR Table1)]
 outQuery3 conn = runQuery conn query3
 
-update1 :: Allow 'Update ps => Conn ps -> IO Int64
+update1 :: Allow 'Update ps => Conn ps Db1 -> IO Int64
 update1 conn = runUpdate conn Table1 upd fil
   where
     fil :: PgR Table1 -> Kol PGBool
@@ -102,6 +102,6 @@ update1 conn = runUpdate conn Table1 upd fil
 
 outQuery1
   :: Allow 'Fetch ps
-  => Conn ps
+  => Conn ps Db1
   -> IO [(HsR Table1, HsR Table1, HsR Table1, Maybe (HsR Table1))]
 outQuery1 conn = runQuery conn query1

--- a/tests/Tutorial.hs
+++ b/tests/Tutorial.hs
@@ -628,7 +628,7 @@ q_Account_agg_subq = proc () -> do
 
 exampleRun
   :: Allow 'Fetch ps
-  => Conn ps
+  => Conn ps Db1
   -> IO ( [HsR Account]
         , [HsR Account]
         , [HsR Account]

--- a/tests/Tutorial.hs
+++ b/tests/Tutorial.hs
@@ -628,7 +628,7 @@ q_Account_agg_subq = proc () -> do
 
 exampleRun
   :: Allow 'Fetch ps
-  => Conn ps Db1
+  => Conn Db1 ps
   -> IO ( [HsR Account]
         , [HsR Account]
         , [HsR Account]


### PR DESCRIPTION
This pull request changed the `Conn ps` type to also be parameterized by the `Database` type `d`. Syntactically this means that  function signatures from `Tisch.Run` changed to look like 

```haskell
-- | Query and fetch zero or more resulting rows.
runQuery
 :: (MonadIO m, Cx.MonadThrow m, PP.Default O.QueryRunner v r, Allow 'Fetch ps)
 => Conn ps d -> Query d () v -> m [r] -- ^
```

Semantically this means that it's now only possible to run a query `Query d a b` with a connection of type `Conn ps d`, preventing any confusion in the case that you have multiple connections open to different databases.

this closes #11   